### PR TITLE
Update: getParameter

### DIFF
--- a/src/Http/Controller/Admin/RoutesController.php
+++ b/src/Http/Controller/Admin/RoutesController.php
@@ -57,7 +57,7 @@ class RoutesController extends AdminController
      */
     public function view(RouteRepositoryInterface $routes)
     {
-        if (!$route = $routes->find($this->route->getParameter('id'))) {
+        if (!$route = $routes->find($this->route->parameter('id'))) {
             abort(404);
         }
 


### PR DESCRIPTION
The getParameter method of the Illuminate\Routing\Route class has been removed. You should use the parameter method instead.